### PR TITLE
Use TCP keepalive for ssh

### DIFF
--- a/terracumber/cucumber.py
+++ b/terracumber/cucumber.py
@@ -43,6 +43,7 @@ class Cucumber:
         chan.update_environment(env_vars)
         chan_stream = chan.makefile()
         print("try to understand 1")
+        tran.set_keepalive(10)
         chan.exec_command(command)
         print("try to understand 2")
         if output_file:


### PR DESCRIPTION
I am under the impression that paramiko loses the connection when running commands between the jenkins worker in Nuremberg and the controller node in Provo.

Using TCP keepalives to try and remediate that.