### PR TITLE
Support terraform.tfsate file missing when looking for bastion hostname

### DIFF
--- a/terracumber-cli
+++ b/terracumber-cli
@@ -215,7 +215,8 @@ def get_bastion_hostname(args, tf_vars):
         terraform = terracumber.terraformer.Terraformer(
             args.gitfolder, args.tf, tf_vars, args.logfile)
         return terraform.get_hostname('bastion')
-    except KeyError:
+    except (KeyError, FileNotFoundError)as error:
+        print(error)
         return None
 
 

--- a/terracumber-cli
+++ b/terracumber-cli
@@ -215,7 +215,7 @@ def get_bastion_hostname(args, tf_vars):
         terraform = terracumber.terraformer.Terraformer(
             args.gitfolder, args.tf, tf_vars, args.logfile)
         return terraform.get_hostname('bastion')
-    except (KeyError, FileNotFoundError)as error:
+    except (KeyError, FileNotFoundError) as error:
         print(error)
         return None
 


### PR DESCRIPTION
When deploying an environment on AWS, we need a bastion. 

There are currently two solutions to that : 
- specify the bastion hostname during terracumber call
- look for this hostname in terraform.tfstate

In my situation, I'm creating a new AWS project where I don't specify the bastion hostname.
Because it's a new project, terraform.tfstate is not present yet.
There is already a try catch exception if bastion hostname value is not set in terraform.tfstate but we don't have this catch if terraform.tfstate file is missing.

This PR is adding this new exception.
