### PR TITLE
Handle basic error conditions

### DIFF
--- a/terracumber-cli
+++ b/terracumber-cli
@@ -325,6 +325,9 @@ def main():
         args.outputdir, template_data['timestamp'])
     if args.runall and dir_existed:
         print("WARNING: %s directory already exists!" % args.outputdir)
+    if not os.path.isfile(args.tf):
+        print("ERROR: file %s from --tf argument does not exist or is not a file" % args.tf)
+        sys.exit(1)
     config = read_config(args.tf)
     if not config:
         sys.exit(1)

--- a/terracumber/config.py
+++ b/terracumber/config.py
@@ -6,7 +6,10 @@ def read_config(path):
     """Return a dictionary with all the variables from a HCL file"""
     config = {}
     with open(path, 'r') as cfg:
-        for key, value in hcl.load(cfg)['variable'].items():
+        hcl_file = hcl.load(cfg)
+        if not 'variable' in hcl_file.keys():
+            return config
+        for key, value in hcl_file['variable'].items():
             try:
                 config[key] = value['default']
             except KeyError:


### PR DESCRIPTION
avoid stack traces when tf file does not exist, or contains no variables at all