### PR TITLE
Detect when placeholder for custom repos is absent from main.tf

### DIFF
--- a/terracumber-cli
+++ b/terracumber-cli
@@ -187,7 +187,10 @@ def run_terraform(args, tf_vars):
                                                     args.logfile, args.terraform_bin)
     if args.custom_repositories:
         with open(args.custom_repositories, 'r') as repos_file:
-            terraform.inject_repos(repos_file)
+            if terraform.inject_repos(repos_file) != 0:
+                print("ERROR: could not inject custom repositories into file %s" % args.tf)
+                print("       make sure you use exactly 1 placeholder for additional repositories")
+                return False
     if args.init:
         terraform.init()
     if args.taint:


### PR DESCRIPTION
Part of the series for added error management in terracumber.

Detect when we have custom repositories in the json file but no placeholder for server in main.tf.

Note: ideally, we should proceed not with text replacement, but with injected variables "the terracumber way". But I have no time for such a refactoring.