### PR TITLE
Support tfvars

### DIFF
--- a/ADVANCED.md
+++ b/ADVANCED.md
@@ -1,0 +1,86 @@
+# Use terraform variable files
+
+To avoid using multiple main.tf having the same deployment and just some variables differences, use the tfvars files with a main template to deploy environment.
+For this example, we will have four type of files : 
+ - main.tf template, deployment description using variables for environment specific parameters
+
+__Example :__
+```terraform
+    server = {
+      provider_settings = {
+        mac = var.ENVIRONMENT_CONFIGURATION[var.ENVIRONMENT].mac["server"]
+        vcpu = 8
+        memory = 32768
+      }
+      additional_repos_only = var.ADDITIONAL_REPOS_ONLY
+      additional_repos = local.additional_repos["server"]
+      image = var.IMAGE
+      additional_packages = [ "venv-salt-minion" ]
+      install_salt_bundle = true
+      server_mounted_mirror = var.MIRROR
+    }
+```
+ - variable.tf file, remove all the variables from the main.tf and move it to a specific file
+   __Example :__
+```terraform
+variable "BRIDGE" {
+  type = string
+}
+
+variable "ADDITIONAL_REPOS_ONLY" {
+  type = bool
+}
+
+variable "ENVIRONMENT_CONFIGURATION" {
+  type = map
+  description = "Collection of  value containing : mac addresses, hypervisor and additional network"
+}
+
+variable "DOWNLOAD_ENDPOINT" {
+  type = string
+  description = "Download enpoint to get build images and set custom_download_endpoint. This value is equal to platform mirror"
+}
+```
+
+ - XXXX.tfvars, you can have as many as you want. Specify the variables depending on the environment. For example mac addresses depending on NUE or PRV environment
+
+__Example :__ 
+```terraform
+############ Nuremberg unique variables ###########
+
+DOMAIN            = "mgr.suse.de"
+MIRROR            = "minima-mirror-ci-bv.mgr.suse.de"
+DOWNLOAD_ENDPOINT = "minima-mirror-ci-bv.mgr.suse.de"
+USE_MIRROR_IMAGES = true
+GIT_PROFILES_REPO = "https://github.com/uyuni-project/uyuni.git#:testsuite/features/profiles/internal_nue"
+BRIDGE            = "br0"
+ENVIRONMENT_CONFIGURATION = {
+  1 = {
+    mac = {
+      controller     = "aa:b2:93:01:03:50"
+      server         = "aa:b2:93:01:03:51"
+      proxy          = "aa:b2:93:01:03:52"
+      suse-minion    = "aa:b2:93:01:03:54"
+      suse-sshminion = "aa:b2:93:01:03:55"
+      rhlike-minion  = "aa:b2:93:01:03:56"
+      deblike-minion = "aa:b2:93:01:03:57"
+      build-host     = "aa:b2:93:01:03:59"
+      kvm-host       = "aa:b2:93:01:03:5a"
+      nested-vm      = "aa:b2:93:01:03:5b"
+    }
+    hypervisor = "suma-08.mgr.suse.de"
+    additional_network = "192.168.111.0/24"
+  }
+}
+
+```
+
+# Deploying environment depending on the product version, environment 
+
+```bash
+                        sh "rm -f ${env.resultdir}/sumaform/terraform.tfvars"
+                        sh "cat ${tfvars_manager43} ${tfvars_nuremberg} >> ${env.resultdir}/sumaform/terraform.tfvars"
+                        sh "echo 'ENVIRONMENT = \'${env_number}\'' >> ${env.resultdir}/sumaform/terraform.tfvars"
+                        sh "cp ${tf_local_variables} ${env.resultdir}/sumaform/"
+
+```

--- a/terracumber-cli
+++ b/terracumber-cli
@@ -20,7 +20,8 @@ def parse_args():
     """Parse arguments"""
     parser = argparse.ArgumentParser(description='Run terrafrom and cucumber')
     parser.add_argument('--tf', help='Path to main.tf file', required=True)
-    parser.add_argument('--tfvars_files', help='Collection of tfvars files path', required=False, default=[])
+    parser.add_argument('--tfvars_files', action='append', help='Collection of tfvars files path', required=False,
+                        default=[])
     parser.add_argument('--tfvariables_file', help='Path to variable.tf file', required=False, default='')
     parser.add_argument('--gitrepo',
                         help='URL to the git repository containing terraform definitions',

--- a/terracumber-cli
+++ b/terracumber-cli
@@ -21,7 +21,7 @@ def parse_args():
     parser = argparse.ArgumentParser(description='Run terrafrom and cucumber')
     parser.add_argument('--tf', help='Path to main.tf file', required=True)
     parser.add_argument('--tfvars_files', help='Collection of tfvars files path', required=False, default=[])
-    parser.add_argument('--tfvariable', help='Path to variable.tf file', required=False)
+    parser.add_argument('--tfvariables_file', help='Path to variable.tf file', required=False)
     parser.add_argument('--gitrepo',
                         help='URL to the git repository containing terraform definitions',
                         default='https://github.com/uyuni-project/sumaform.git')
@@ -186,7 +186,8 @@ def run_terraform(args, tf_vars):
     """ Prepare the environment """
     terraform = terracumber.terraformer.Terraformer(args.gitfolder, args.tf,
                                                     args.sumaform_backend, tf_vars,
-                                                    args.logfile, args.terraform_bin)
+                                                    args.logfile, args.terraform_bin, args.tfvariables_file,
+                                                    args.tfvars_files)
     if args.custom_repositories:
         with open(args.custom_repositories, 'r') as repos_file:
             error = terraform.inject_repos(repos_file)

--- a/terracumber-cli
+++ b/terracumber-cli
@@ -23,7 +23,8 @@ def parse_args():
     parser.add_argument('--tf_configuration_files', action='append', help='Path to terraform configuration file ('
                                                                           'tfvars)', required=False,
                         default=[])
-    parser.add_argument('--tf_variables_description_file', help='Path to variables description file (variables.tf)', required=False, default='')
+    parser.add_argument('--tf_variables_description_file', help='Path to variables description file (variables.tf)',
+                        required=False, default='')
     parser.add_argument('--gitrepo',
                         help='URL to the git repository containing terraform definitions',
                         default='https://github.com/uyuni-project/sumaform.git')

--- a/terracumber-cli
+++ b/terracumber-cli
@@ -20,6 +20,8 @@ def parse_args():
     """Parse arguments"""
     parser = argparse.ArgumentParser(description='Run terrafrom and cucumber')
     parser.add_argument('--tf', help='Path to main.tf file', required=True)
+    parser.add_argument('--tfvars_files', help='Collection of tfvars files path', required=False, default=[])
+    parser.add_argument('--tfvariable', help='Path to variable.tf file', required=False)
     parser.add_argument('--gitrepo',
                         help='URL to the git repository containing terraform definitions',
                         default='https://github.com/uyuni-project/sumaform.git')
@@ -199,8 +201,8 @@ def run_terraform(args, tf_vars):
     if args.taint:
         terraform.taint(args.taint)
     if args.destroy:
-        terraform.destroy()
-    result = terraform.apply()
+        terraform.destroy(args.tfvars_files)
+    result = terraform.apply(args.parallelism, args.tfvars_files)
     if result == 0:
         return True
     return False

--- a/terracumber-cli
+++ b/terracumber-cli
@@ -21,8 +21,7 @@ def parse_args():
     parser = argparse.ArgumentParser(description='Run terrafrom and cucumber')
     parser.add_argument('--tf', help='Path to main.tf file', required=True)
     parser.add_argument('--tf_configuration_files', action='append', help='Path to terraform configuration file ('
-                                                                          'tfvars)', required=False,
-                        default=[])
+                        'tfvars)', required=False, default=[])
     parser.add_argument('--tf_variables_description_file', help='Path to variables description file (variables.tf)',
                         required=False, default='')
     parser.add_argument('--gitrepo',

--- a/terracumber-cli
+++ b/terracumber-cli
@@ -190,8 +190,8 @@ def run_terraform(args, tf_vars):
     """ Prepare the environment """
     terraform = terracumber.terraformer.Terraformer(args.gitfolder, args.tf,
                                                     args.sumaform_backend, tf_vars,
-                                                    args.logfile, args.terraform_bin, args.tfvariables_file,
-                                                    args.tfvars_files)
+                                                    args.logfile, args.terraform_bin,
+                                                    args.tfvariables_file, args.tfvars_files)
     if args.custom_repositories:
         with open(args.custom_repositories, 'r') as repos_file:
             error = terraform.inject_repos(repos_file)

--- a/terracumber-cli
+++ b/terracumber-cli
@@ -20,9 +20,10 @@ def parse_args():
     """Parse arguments"""
     parser = argparse.ArgumentParser(description='Run terrafrom and cucumber')
     parser.add_argument('--tf', help='Path to main.tf file', required=True)
-    parser.add_argument('--tfvars_files', action='append', help='Path to tfvars file', required=False,
+    parser.add_argument('--tf_configuration_files', action='append', help='Path to terraform configuration file ('
+                                                                          'tfvars)', required=False,
                         default=[])
-    parser.add_argument('--tfvariables_file', help='Path to variable.tf file', required=False, default='')
+    parser.add_argument('--tf_variables_description_file', help='Path to variables description file (variables.tf)', required=False, default='')
     parser.add_argument('--gitrepo',
                         help='URL to the git repository containing terraform definitions',
                         default='https://github.com/uyuni-project/sumaform.git')
@@ -106,10 +107,10 @@ def parse_args():
     return args
 
 
-def read_config(tf_file, tfvariables_file):
+def read_config(tf_file, tf_variables_description_file):
     """Read and validate the config from a tf file"""
-    if tfvariables_file != '':
-        config = terracumber.config.read_config(tfvariables_file)
+    if tf_variables_description_file != '':
+        config = terracumber.config.read_config(tf_variables_description_file)
     else:
         config = terracumber.config.read_config(tf_file)
     for required in ['URL_PREFIX', 'CUCUMBER_COMMAND', 'CUCUMBER_BRANCH', 'CUCUMBER_RESULTS',
@@ -191,7 +192,7 @@ def run_terraform(args, tf_vars):
     terraform = terracumber.terraformer.Terraformer(args.gitfolder, args.tf,
                                                     args.sumaform_backend, tf_vars,
                                                     args.logfile, args.terraform_bin,
-                                                    args.tfvariables_file, args.tfvars_files)
+                                                    args.tf_variables_description_file, args.tf_configuration_files)
     if args.custom_repositories:
         with open(args.custom_repositories, 'r') as repos_file:
             error = terraform.inject_repos(repos_file)
@@ -344,7 +345,7 @@ def main():
     if not os.path.isfile(args.tf):
         print("ERROR: file %s from --tf argument does not exist or is not a file" % args.tf)
         sys.exit(1)
-    config = read_config(args.tf, args.tfvariables_file)
+    config = read_config(args.tf, args.tf_variables_description_file)
     if not config:
         sys.exit(1)
     tf_vars = get_tf_vars()

--- a/terracumber-cli
+++ b/terracumber-cli
@@ -206,7 +206,7 @@ def run_terraform(args, tf_vars):
     if args.taint:
         terraform.taint(args.taint)
     if args.destroy:
-        terraform.destroy(args.tfvars_files)
+        terraform.destroy()
     result = terraform.apply(args.parallelism)
     if result == 0:
         return True

--- a/terracumber-cli
+++ b/terracumber-cli
@@ -21,7 +21,7 @@ def parse_args():
     parser = argparse.ArgumentParser(description='Run terrafrom and cucumber')
     parser.add_argument('--tf', help='Path to main.tf file', required=True)
     parser.add_argument('--tfvars_files', help='Collection of tfvars files path', required=False, default=[])
-    parser.add_argument('--tfvariables_file', help='Path to variable.tf file', required=False)
+    parser.add_argument('--tfvariables_file', help='Path to variable.tf file', required=False, default='')
     parser.add_argument('--gitrepo',
                         help='URL to the git repository containing terraform definitions',
                         default='https://github.com/uyuni-project/sumaform.git')

--- a/terracumber-cli
+++ b/terracumber-cli
@@ -20,7 +20,7 @@ def parse_args():
     """Parse arguments"""
     parser = argparse.ArgumentParser(description='Run terrafrom and cucumber')
     parser.add_argument('--tf', help='Path to main.tf file', required=True)
-    parser.add_argument('--tfvars_files', action='append', help='Collection of tfvars files path', required=False,
+    parser.add_argument('--tfvars_files', action='append', help='Path to tfvars file', required=False,
                         default=[])
     parser.add_argument('--tfvariables_file', help='Path to variable.tf file', required=False, default='')
     parser.add_argument('--gitrepo',

--- a/terracumber-cli
+++ b/terracumber-cli
@@ -207,7 +207,7 @@ def run_terraform(args, tf_vars):
         terraform.taint(args.taint)
     if args.destroy:
         terraform.destroy(args.tfvars_files)
-    result = terraform.apply(args.parallelism, args.tfvars_files)
+    result = terraform.apply(args.parallelism)
     if result == 0:
         return True
     return False

--- a/terracumber-cli
+++ b/terracumber-cli
@@ -105,9 +105,12 @@ def parse_args():
     return args
 
 
-def read_config(tf_file):
+def read_config(tf_file, tfvariables_file):
     """Read and validate the config from a tf file"""
-    config = terracumber.config.read_config(tf_file)
+    if tfvariables_file != '':
+        config = terracumber.config.read_config(tfvariables_file)
+    else:
+        config = terracumber.config.read_config(tf_file)
     for required in ['URL_PREFIX', 'CUCUMBER_COMMAND', 'CUCUMBER_BRANCH', 'CUCUMBER_RESULTS',
                      'MAIL_SUBJECT', 'MAIL_TEMPLATE', 'MAIL_SUBJECT_ENV_FAIL',
                      'MAIL_TEMPLATE_ENV_FAIL', 'MAIL_FROM', 'MAIL_TO']:
@@ -340,7 +343,7 @@ def main():
     if not os.path.isfile(args.tf):
         print("ERROR: file %s from --tf argument does not exist or is not a file" % args.tf)
         sys.exit(1)
-    config = read_config(args.tf)
+    config = read_config(args.tf, args.tfvariables_file)
     if not config:
         sys.exit(1)
     tf_vars = get_tf_vars()

--- a/terracumber/terraformer.py
+++ b/terracumber/terraformer.py
@@ -26,7 +26,7 @@ class Terraformer:
     terraform_bin - path to terraform bin
     """
 
-    def __init__(self, terraform_path, maintf, backend, variables={}, output_file=False, terraform_bin='/usr/bin/terraform', variables_declaration_file="", tfvars_files=[]):
+    def __init__(self, terraform_path, maintf, backend, variables={}, output_file=False, terraform_bin='/usr/bin/terraform', variables_description_file="", tfvars_files=[]):
         self.terraform_path = terraform_path
         self.maintf = maintf
         self.variables = variables
@@ -36,8 +36,8 @@ class Terraformer:
         self.output_file = output_file
         self.terraform_bin = terraform_bin
         copy(maintf, terraform_path + '/main.tf')
-        if path.isfile(variables_declaration_file):
-            copy(variables_declaration_file, terraform_path + '/variables.tf')
+        if path.isfile(variables_description_file):
+            copy(variables_description_file, terraform_path + '/variables.tf')
         for tfvars_file in tfvars_files:
             copy(tfvars_file, terraform_path)
             self.tfvars_files.append(path.basename(tfvars_file))

--- a/terracumber/terraformer.py
+++ b/terracumber/terraformer.py
@@ -3,7 +3,7 @@ import fileinput
 from json import load, JSONDecodeError
 from os import environ, path, symlink, unlink
 from re import match, subn
-from shutil import copy, copyfile
+from shutil import copy
 from subprocess import CalledProcessError, Popen, PIPE, STDOUT
 
 # Fallback to allow running python3 -m unittest
@@ -40,7 +40,7 @@ class Terraformer:
         if path.isfile(variables_file):
             copy(variables_file, terraform_path + '/variables.tf')
         for tfvars_file in tfvars_files:
-            copyfile(tfvars_file, terraform_path)
+            copy(tfvars_file, terraform_path)
         # Only if we are using a folder with folder structure used by sumaform
         if path.exists('%s/backend_modules/%s' % (path.abspath(terraform_path), backend)):
             if path.islink('%s/modules/backend' % terraform_path):

--- a/terracumber/terraformer.py
+++ b/terracumber/terraformer.py
@@ -26,7 +26,7 @@ class Terraformer:
     terraform_bin - path to terraform bin
     """
 
-    def __init__(self, terraform_path, maintf, backend, variables={}, output_file=False, terraform_bin='/usr/bin/terraform', variables_file="", tfvars_files=[]):
+    def __init__(self, terraform_path, maintf, backend, variables={}, output_file=False, terraform_bin='/usr/bin/terraform', variables_declaration_file="", tfvars_files=[]):
         self.terraform_path = terraform_path
         self.maintf = maintf
         self.variables = variables
@@ -36,8 +36,8 @@ class Terraformer:
         self.output_file = output_file
         self.terraform_bin = terraform_bin
         copy(maintf, terraform_path + '/main.tf')
-        if path.isfile(variables_file):
-            copy(variables_file, terraform_path + '/variables.tf')
+        if path.isfile(variables_declaration_file):
+            copy(variables_declaration_file, terraform_path + '/variables.tf')
         for tfvars_file in tfvars_files:
             copy(tfvars_file, terraform_path)
             self.tfvars_files.append(path.basename(tfvars_file))

--- a/terracumber/terraformer.py
+++ b/terracumber/terraformer.py
@@ -30,8 +30,7 @@ class Terraformer:
         self.terraform_path = terraform_path
         self.maintf = maintf
         self.variables = variables
-        self.variables_file = variables_file
-        self.tfvars_files = tfvars_files
+        self.tfvars_files = []
         if self.variables is None:
             self.variables = {}
         self.output_file = output_file
@@ -41,6 +40,7 @@ class Terraformer:
             copy(variables_file, terraform_path + '/variables.tf')
         for tfvars_file in tfvars_files:
             copy(tfvars_file, terraform_path)
+            self.tfvars_files.append(path.basename(tfvars_file))
         # Only if we are using a folder with folder structure used by sumaform
         if path.exists('%s/backend_modules/%s' % (path.abspath(terraform_path), backend)):
             if path.islink('%s/modules/backend' % terraform_path):
@@ -94,20 +94,20 @@ class Terraformer:
             print(resource)
             self.__run_command([self.terraform_bin, "taint", "%s" % resource])
 
-    def apply(self, parallelism=10, tfvars_files=[]):
+    def apply(self, parallelism=10):
         """Run terraform apply
 
         parallelism - Define the number of parallel resource operations. Defaults to 10 as specified by terraform.
         """
         command_arguments = [self.terraform_bin, "apply", "-auto-approve", "-parallelism=%s" % parallelism]
-        for file in tfvars_files:
+        for file in self.tfvars_files:
             command_arguments.append("-var-file=%s" % file)
         return self.__run_command(command_arguments)
 
     def destroy(self, tfvars_files=[]):
         """Run terraform destroy"""
         command_arguments = [self.terraform_bin, "destroy", "-auto-approve"]
-        for file in tfvars_files:
+        for file in self.tfvars_files:
             command_arguments.append("-var-file=%s" % file)
         self.__run_command(command_arguments)
 

--- a/terracumber/terraformer.py
+++ b/terracumber/terraformer.py
@@ -104,7 +104,7 @@ class Terraformer:
             command_arguments.append("-var-file=%s" % file)
         return self.__run_command(command_arguments)
 
-    def destroy(self, tfvars_files=[]):
+    def destroy(self):
         """Run terraform destroy"""
         command_arguments = [self.terraform_bin, "destroy", "-auto-approve"]
         for file in self.tfvars_files:


### PR DESCRIPTION
The PR testing needs a lot of environment ( 16 environments will be describe ).
Managing all this environment by using main.tf will increase the maintenance work, any change will need to be impacted on the 16 main.tf.

To deal with this issue, I introduce a template-main.tf configurable using a variable file description and tfvars unique to product version and environment ( NUE or PRV ).

I added this new files support to terracucumber.
The changes are : 
 - copy this new files inside result/sumaform
 - use -var-file argument when calling terraform apply
 - add the possibility to verify a variable.tf file when checking the mandatory variable
Related to :
Issue : https://github.com/SUSE/spacewalk/issues/21471
CI PR : https://github.com/SUSE/susemanager-ci/pull/898/files

