### PR TITLE
Avoid checking floating point values for equality

### DIFF
--- a/test/test_junit.py
+++ b/test/test_junit.py
@@ -1,5 +1,7 @@
 from terracumber import junit
+from math import isclose
 import unittest
+
 
 
 class TestJunit(unittest.TestCase):
@@ -20,8 +22,13 @@ class TestJunit(unittest.TestCase):
         self.assertListEqual(self.junit.sort_test_files_by_mtime(), file_list)
 
     def test_get_totals(self):
-        totals = {'failures': 3, 'errors': 0, 'skipped': 0, 'passed': 63, 'tests': 66, 'time': 1334.586592}
-        self.assertDictEqual(self.junit.get_totals(), totals)
+        expected_totals = {'failures': 3, 'errors': 0, 'skipped': 0, 'passed': 63, 'tests': 66, 'time': 1334.586592}
+        computed_totals = self.junit.get_totals()
+        # avoid testing floats for equality
+        self.assertTrue(isclose(expected_totals['time'], computed_totals['time']))
+        del expected_totals['time']
+        del computed_totals['time']
+        self.assertDictEqual(computed_totals, expected_totals)
 
     def test_get_failures(self):
         failure_messages = [


### PR DESCRIPTION
Avoid a floating point values equality check in TestJunit::test_get_totals.

We have noticed the following failing test in https://github.com/uyuni-project/terracumber/pull/30

```
FAILED test/test_junit.py::TestJunit::test_get_totals - AssertionError: {'fai[29 chars]ped': 0, 'passed': 63, 'tests': 66, 'time': 1334.5865919999999} != {'fai[29 chars]ped': 0, 'passed': 63, 'tests': 66, 'time': 1334.586592}
  {'errors': 0,
   'failures': 3,
   'passed': 63,
   'skipped': 0,
   'tests': 66,
-  'time': 1334.5865919999999}
?                    ^^^^^^^^

+  'time': 1334.586592}
```

Looks like to be just a rounding difference due to floating point precision.
As that is often time dependent on architectures, programming languages etc it might be better to remove the equality check altogether and just check that the 2 values are _really_ close