### PR TITLE
Correctly add quote to name when injection repository

### DIFF
--- a/terracumber/terraformer.py
+++ b/terracumber/terraformer.py
@@ -67,7 +67,7 @@ class Terraformer:
                     replacement_list = ["additional_repos = {"]
                     for name, url in node_mu_repos.items():
                         replacement_list.append(f'\n    "{name}" = "{url}"')
-                    replacement_list.append("\n  }")
+                    replacement_list.append("\n}")
                     replacement = ''.join(replacement_list)
                     placeholder = f'//{node}_additional_repos'
                     n_replaced = 0

--- a/terracumber/terraformer.py
+++ b/terracumber/terraformer.py
@@ -66,12 +66,12 @@ class Terraformer:
                     node_mu_repos = repos.get(node, None)
                     replacement_list = ["additional_repos = {"]
                     for name, url in node_mu_repos.items():
-                        replacement_list.append(f'\n{" " * 4}{name} = "{url}"')
+                        replacement_list.append(f'\n    "{name}" = "{url}"')
                     replacement_list.append("\n  }")
                     replacement = ''.join(replacement_list)
-                    placeholder = '//' + node + '_additional_repos'
+                    placeholder = f'//{node}_additional_repos'
                     n_replaced = 0
-                    for line in fileinput.input("%s/main.tf" % self.terraform_path, inplace=True):
+                    for line in fileinput.input(f"{self.terraform_path}/main.tf", inplace=True):
                         (new_line, n) = subn(placeholder, replacement, line)
                         print(new_line, end='')
                         n_replaced += n


### PR DESCRIPTION
## Context 
When trying to reuse a main.tf file, `hcl.load` module is failing to read `main.tf` because the injected repositories doesn't have quotes.

## Error 
```python
Traceback (most recent call last):
  File "./terracumber-cli", line 477, in <module>
    main()
  File "./terracumber-cli", line 396, in main
    config = read_config(args.tf, args.tf_variables_description_file)
  File "./terracumber-cli", line 127, in read_config
    config = terracumber.config.read_config(tf_file)
  File "/home/jenkins/workspace/manager-4.3-qe-build-validation-NUE-cleaning/terracumber/config.py", line 9, in read_config
    hcl_file = hcl.load(cfg)
  File "/usr/lib64/python3.6/site-packages/hcl/api.py", line 59, in load
    return loads(fp.read(), export_comments=export_comments)
  File "/usr/lib64/python3.6/site-packages/hcl/api.py", line 78, in loads
    return HclParser().parse(s, export_comments=export_comments)
  File "/usr/lib64/python3.6/site-packages/hcl/parser.py", line 632, in parse
    s, lexer=Lexer(export_comments=export_comments), debug=DEBUG
  File "/usr/lib64/python3.6/site-packages/hcl/ply/yacc.py", line 335, in parse
    return self.parseopt_notrack(input, lexer, debug, tracking, tokenfunc)
  File "/usr/lib64/python3.6/site-packages/hcl/ply/yacc.py", line 1203, in parseopt_notrack
    tok = call_errorfunc(self.errorfunc, errtoken, self)
  File "/usr/lib64/python3.6/site-packages/hcl/ply/yacc.py", line 194, in call_errorfunc
    r = errorfunc(token)
  File "/usr/lib64/python3.6/site-packages/hcl/parser.py", line 623, in p_error
    raise ValueError(msg)
ValueError: Line 349, column 7890: unexpected EQUAL

script returned exit code 1
```

### Additional package block creating the error

```hcl
additional_repos = {
    35083 = "http://download.suse.de/ibs/SUSE:/Maintenance:/35083/SUSE_Updates_SLE-Module-SUSE-Manager-Server_4.3_x86_64/"
    34966 = "http://download.suse.de/ibs/SUSE:/Maintenance:/34966/SUSE_Updates_SLE-Product-SUSE-Manager-Server_4.3_x86_64/"
  }
```

## Correct block 

```hcl
additional_repos = {
    "35083" = "http://download.suse.de/ibs/SUSE:/Maintenance:/35083/SUSE_Updates_SLE-Module-SUSE-Manager-Server_4.3_x86_64/"
    "34966" = "http://download.suse.de/ibs/SUSE:/Maintenance:/34966/SUSE_Updates_SLE-Product-SUSE-Manager-Server_4.3_x86_64/"
  }
```