### PR TITLE
Remove all comments from man.tf when removing module

### DIFF
--- a/terracumber/tf_module_cleaner.py
+++ b/terracumber/tf_module_cleaner.py
@@ -70,7 +70,7 @@ tf_resources_to_delete - List of resources to remove ( can only be proxy, monito
 def remove_unselected_tf_resources(maintf_file, tf_resources_to_keep, tf_resources_to_delete):
     with open(maintf_file, 'r') as file:
         data = file.read()
-
+    data = [line for line in data if not line.strip().startswith("//")]
     modules = data.split("module ")
 
     tf_resources_to_keep.extend(get_default_modules(data, tf_resources_to_delete))

--- a/terracumber/tf_module_cleaner.py
+++ b/terracumber/tf_module_cleaner.py
@@ -84,7 +84,7 @@ def remove_unselected_tf_resources(maintf_file, tf_resources_to_keep, tf_resourc
             data = data.replace("module " + module, '')
         elif module_name == 'controller':
             data = data.replace(module, filter_module_references(module, tf_resources_to_keep))
-
+    logger.info(f"Data is {data}")
     cleaned_content = re.sub(r'\n{3,}', '\n\n', data)
     with open(maintf_file, 'w') as file:
         file.write(cleaned_content)

--- a/terracumber/tf_module_cleaner.py
+++ b/terracumber/tf_module_cleaner.py
@@ -62,7 +62,7 @@ def filter_module_references(maintf_content, tf_resources_to_keep):
 
 """
 Removes modules and controller references from resources not in the resources to keep list.
-Removes comments upside modules from main.tf.
+Removes comments outside modules from main.tf.
 
 maintf_file - Path to the main.tf file
 tf_resources_to_keep - List of resources to keep

--- a/terracumber/tf_module_cleaner.py
+++ b/terracumber/tf_module_cleaner.py
@@ -70,7 +70,7 @@ tf_resources_to_delete - List of resources to remove ( can only be proxy, monito
 def remove_unselected_tf_resources(maintf_file, tf_resources_to_keep, tf_resources_to_delete):
     with open(maintf_file, 'r') as file:
         data = file.read()
-    filtered_lines = [line for line in data if not line.strip().startswith("//")]
+    filtered_lines = [line for line in lines if not line.lstrip().startswith("//")]
     data = ''.join(filtered_lines)
     modules = data.split("module ")
 

--- a/terracumber/tf_module_cleaner.py
+++ b/terracumber/tf_module_cleaner.py
@@ -72,11 +72,16 @@ def remove_unselected_tf_resources(maintf_file, tf_resources_to_keep, tf_resourc
     with open(maintf_file, 'r') as file:
         raw_data = file.read()
 #     filtered_lines = [line for line in raw_data if not line.lstrip().startswith("//")]
-    for line in raw_data:
-        if not line.startswith("//"):
-            filtered_lines = line
-        else:
-            logger.info(f"Remove comment line : {line}")
+    # Regex to match lines that start with "//" followed by optional spaces
+    pattern = re.compile(r'^\s*//')
+
+    # Filter out lines that match the pattern
+    filtered_lines = [line for line in lines if not pattern.match(raw_data)]
+#     for line in raw_data:
+#         if not line.startswith("//"):
+#             filtered_lines = line
+#         else:
+#             logger.info(f"Remove comment line : {line}")
     data = ''.join(filtered_lines)
     logger.info(f"Remove comments : {data}")
     modules = data.split("module ")

--- a/terracumber/tf_module_cleaner.py
+++ b/terracumber/tf_module_cleaner.py
@@ -76,7 +76,7 @@ def remove_unselected_tf_resources(maintf_file, tf_resources_to_keep, tf_resourc
     pattern = re.compile(r'^\s*//')
 
     # Filter out lines that match the pattern
-    filtered_lines = [line for line in lines if not pattern.match(raw_data)]
+    filtered_lines = [line for line in raw_data if not pattern.match(line)]
 #     for line in raw_data:
 #         if not line.startswith("//"):
 #             filtered_lines = line

--- a/terracumber/tf_module_cleaner.py
+++ b/terracumber/tf_module_cleaner.py
@@ -70,7 +70,8 @@ tf_resources_to_delete - List of resources to remove ( can only be proxy, monito
 def remove_unselected_tf_resources(maintf_file, tf_resources_to_keep, tf_resources_to_delete):
     with open(maintf_file, 'r') as file:
         data = file.read()
-    data = [line for line in data if not line.strip().startswith("//")]
+    filter_lines = [line for line in data if not line.strip().startswith("//")]
+    data = ''.join(filtered_lines)
     modules = data.split("module ")
 
     tf_resources_to_keep.extend(get_default_modules(data, tf_resources_to_delete))
@@ -78,13 +79,11 @@ def remove_unselected_tf_resources(maintf_file, tf_resources_to_keep, tf_resourc
 
     for module in modules[1:]:
         module_name = module.split('"')[1]
-        logger.info(f"Module data for {module_name} is {module}")
         if module_name not in tf_resources_to_keep :
             logger.info(f"Removing minion {module_name} from main.tf")
             data = data.replace("module " + module, '')
         elif module_name == 'controller':
             data = data.replace(module, filter_module_references(module, tf_resources_to_keep))
-    logger.info(f"Data is {data}")
     cleaned_content = re.sub(r'\n{3,}', '\n\n', data)
     with open(maintf_file, 'w') as file:
         file.write(cleaned_content)

--- a/terracumber/tf_module_cleaner.py
+++ b/terracumber/tf_module_cleaner.py
@@ -70,7 +70,7 @@ tf_resources_to_delete - List of resources to remove ( can only be proxy, monito
 def remove_unselected_tf_resources(maintf_file, tf_resources_to_keep, tf_resources_to_delete):
     with open(maintf_file, 'r') as file:
         data = file.read()
-    filtered_lines = [line for line in lines if not line.lstrip().startswith("//")]
+    filtered_lines = [line for line in data if not line.lstrip().startswith("//")]
     data = ''.join(filtered_lines)
     modules = data.split("module ")
 

--- a/terracumber/tf_module_cleaner.py
+++ b/terracumber/tf_module_cleaner.py
@@ -70,9 +70,10 @@ tf_resources_to_delete - List of resources to remove ( can only be proxy, monito
 """
 def remove_unselected_tf_resources(maintf_file, tf_resources_to_keep, tf_resources_to_delete):
     with open(maintf_file, 'r') as file:
-        data = file.read()
-    filtered_lines = [line for line in data if not line.lstrip().startswith("//")]
+        raw_data = file.read()
+    filtered_lines = [line for line in raw_data if not line.lstrip().startswith("//")]
     data = ''.join(filtered_lines)
+    logger.info(f"Remove comments : {data}")
     modules = data.split("module ")
 
     tf_resources_to_keep.extend(get_default_modules(data, tf_resources_to_delete))

--- a/terracumber/tf_module_cleaner.py
+++ b/terracumber/tf_module_cleaner.py
@@ -70,7 +70,7 @@ tf_resources_to_delete - List of resources to remove ( can only be proxy, monito
 def remove_unselected_tf_resources(maintf_file, tf_resources_to_keep, tf_resources_to_delete):
     with open(maintf_file, 'r') as file:
         data = file.read()
-    filter_lines = [line for line in data if not line.strip().startswith("//")]
+    filtered_lines = [line for line in data if not line.strip().startswith("//")]
     data = ''.join(filtered_lines)
     modules = data.split("module ")
 

--- a/terracumber/tf_module_cleaner.py
+++ b/terracumber/tf_module_cleaner.py
@@ -62,6 +62,7 @@ def filter_module_references(maintf_content, tf_resources_to_keep):
 
 """
 Removes modules and controller references from resources not in the resources to keep list.
+Removes comments upside modules from main.tf.
 
 maintf_file - Path to the main.tf file
 tf_resources_to_keep - List of resources to keep

--- a/terracumber/tf_module_cleaner.py
+++ b/terracumber/tf_module_cleaner.py
@@ -71,7 +71,12 @@ tf_resources_to_delete - List of resources to remove ( can only be proxy, monito
 def remove_unselected_tf_resources(maintf_file, tf_resources_to_keep, tf_resources_to_delete):
     with open(maintf_file, 'r') as file:
         raw_data = file.read()
-    filtered_lines = [line for line in raw_data if not line.lstrip().startswith("//")]
+#     filtered_lines = [line for line in raw_data if not line.lstrip().startswith("//")]
+    for line in raw_data:
+        if not line.startswith("//"):
+            filtered_lines = line
+        else:
+            logger.info(f"Remove comment line : {line}")
     data = ''.join(filtered_lines)
     logger.info(f"Remove comments : {data}")
     modules = data.split("module ")

--- a/terracumber/tf_module_cleaner.py
+++ b/terracumber/tf_module_cleaner.py
@@ -70,22 +70,11 @@ tf_resources_to_delete - List of resources to remove ( can only be proxy, monito
 """
 def remove_unselected_tf_resources(maintf_file, tf_resources_to_keep, tf_resources_to_delete):
     with open(maintf_file, 'r') as file:
-        raw_data = file.read()
-#     filtered_lines = [line for line in raw_data if not line.lstrip().startswith("//")]
-    # Regex to match lines that start with "//" followed by optional spaces
-    pattern = re.compile(r'^\s*//')
+        raw_data = file.readlines()
 
-    # Filter out lines that match the pattern
-    filtered_lines = [line for line in raw_data if not pattern.match(line)]
-#     for line in raw_data:
-#         if not line.startswith("//"):
-#             filtered_lines = line
-#         else:
-#             logger.info(f"Remove comment line : {line}")
+    filtered_lines = [line for line in raw_data if not line.lstrip().startswith("//")]
     data = ''.join(filtered_lines)
-    logger.info(f"Remove comments : {data}")
     modules = data.split("module ")
-
     tf_resources_to_keep.extend(get_default_modules(data, tf_resources_to_delete))
     logger.info(f"Resources to keep {tf_resources_to_keep}.")
 

--- a/terracumber/tf_module_cleaner.py
+++ b/terracumber/tf_module_cleaner.py
@@ -78,6 +78,7 @@ def remove_unselected_tf_resources(maintf_file, tf_resources_to_keep, tf_resourc
 
     for module in modules[1:]:
         module_name = module.split('"')[1]
+        logger.info(f"Module data for {module_name} is {module}")
         if module_name not in tf_resources_to_keep :
             logger.info(f"Removing minion {module_name} from main.tf")
             data = data.replace("module " + module, '')


### PR DESCRIPTION
## Context

Depending on the comment description, it can make the module removal unstable.

## Solution

In a context of removing the modules, remove all the comments that are outside modules ( root level )

## Example

```terraform
module "slemicro55_minion" {
  source             = "./modules/minion"
  base_configuration = module.base_core.configuration
  product_version    = "4.3-released"
  name               = "slemicro55-minion"
  image              = "slemicro55o"
  provider_settings = {
    mac                = "aa:b2:92:42:00:ca"
    memory             = 2048
  }

  server_configuration = {
    hostname = "suma-bv-43-proxy.mgr.suse.de"
  }
  auto_connect_to_master  = false
  use_os_released_updates = false
  ssh_key_path            = "./salt/controller/id_rsa.pub"

  // WORKAROUND: Does not work in sumaform, yet
  //  additional_packages = [ "venv-salt-minion" ]
  install_salt_bundle = false
}
```

Comments will *NOT* be deleted

```terraform
//  WORKAROUND until https://bugzilla.suse.com/show_bug.cgi?id=1208045 gets fixed
// module "slemicro52_sshminion" {
//   source             = "./modules/sshminion"
//   base_configuration = module.base_core.configuration
//   product_version    = "4.3-released"
//   name               = "slemicro52-sshminion"
//   image              = "slemicro52-ign"
//   provider_settings = {
//     mac                = "aa:b2:92:42:00:e7"
//     memory             = 2048
//   }
//   use_os_released_updates = false
//   ssh_key_path            = "./salt/controller/id_rsa.pub"
// }
```

This comment will be deleted.