### PR TITLE
Upgrade to hcl2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-pyhcl
+python-hcl2
 paramiko
 pygit2

--- a/terracumber/config.py
+++ b/terracumber/config.py
@@ -5,8 +5,8 @@ def read_config(path):
     """Return a dictionary with all the variables from a HCL file"""
     config = {}
     with open(path, 'r') as cfg:
-        hcl_file = hcl2.load(cfg)  # Use hcl2 for better parsing
-        if 'variable' not in hcl_file.keys():
+        hcl_file = hcl2.load(cfg)
+        if not 'variable' in hcl_file.keys():
             return config
         for key, value in hcl_file['variable'].items():
             try:

--- a/terracumber/config.py
+++ b/terracumber/config.py
@@ -1,3 +1,4 @@
+"""Manage HCL files as configuration files"""
 import hcl2
 
 def flatten(value):

--- a/terracumber/config.py
+++ b/terracumber/config.py
@@ -1,13 +1,12 @@
 """Manage HCL files as configuration files"""
-import hcl
-
+import hcl2
 
 def read_config(path):
     """Return a dictionary with all the variables from a HCL file"""
     config = {}
     with open(path, 'r') as cfg:
-        hcl_file = hcl.load(cfg)
-        if not 'variable' in hcl_file.keys():
+        hcl_file = hcl2.load(cfg)  # Use hcl2 for better parsing
+        if 'variable' not in hcl_file.keys():
             return config
         for key, value in hcl_file['variable'].items():
             try:

--- a/terracumber/config.py
+++ b/terracumber/config.py
@@ -6,11 +6,22 @@ def read_config(path):
     config = {}
     with open(path, 'r') as cfg:
         hcl_file = hcl2.load(cfg)
-        if not 'variable' in hcl_file.keys():
+
+        # Debugging the structure of hcl_file
+        print(hcl_file)  # Print to check the structure
+
+        if 'variable' not in hcl_file:
             return config
-        for key, value in hcl_file['variable'].items():
-            try:
-                config[key] = value['default']
-            except KeyError:
-                pass
+
+        # Ensure 'variable' is a dictionary before accessing its items
+        if isinstance(hcl_file['variable'], dict):
+            for key, value in hcl_file['variable'].items():
+                try:
+                    config[key] = value['default']
+                except KeyError:
+                    pass
+        else:
+            print("Unexpected format for 'variable':", type(hcl_file['variable']))
+
     return config
+


### PR DESCRIPTION
## What does this PR ?

To be able to deploy liberty linux 9 on BV, we overwrite base_configuration using this block : 

```terraform
  base_configuration = merge(module.base_res.configuration,
  {
    testsuite = false
  })
```

This block is crashing the hcl read block with this error 
```bash
14:32:35  + ./terracumber-cli --outputdir /home/jenkins/workspace/manager-5.0-qe-build-validation-PRV/results --tf susemanager-ci/terracumber_config/tf_files/SUSEManager-5.0-build-validation-PRV.tf --gitfolder /home/jenkins/workspace/manager-5.0-qe-build-validation-PRV/results/sumaform --logfile /home/jenkins/workspace/manager-5.0-qe-build-validation-PRV/results/29/mail.log --runstep mail
14:32:35  Traceback (most recent call last):
14:32:35    File "./terracumber-cli", line 488, in <module>
14:32:35      main()
14:32:35    File "./terracumber-cli", line 407, in main
14:32:35      config = read_config(args.tf, args.tf_variables_description_file, args.tf_variables_product_file)
14:32:35    File "./terracumber-cli", line 129, in read_config
14:32:35      config = terracumber.config.read_config(tf_file)
14:32:35    File "/home/jenkins/workspace/manager-5.0-qe-build-validation-PRV/terracumber/config.py", line 15, in read_config
14:32:35      hcl_file = hcl.load(cfg)
14:32:35    File "/usr/lib64/python3.6/site-packages/hcl/api.py", line 59, in load
14:32:35      return loads(fp.read(), export_comments=export_comments)
14:32:35    File "/usr/lib64/python3.6/site-packages/hcl/api.py", line 78, in loads
14:32:35      return HclParser().parse(s, export_comments=export_comments)
14:32:35    File "/usr/lib64/python3.6/site-packages/hcl/parser.py", line 632, in parse
14:32:35      s, lexer=Lexer(export_comments=export_comments), debug=DEBUG
14:32:35    File "/usr/lib64/python3.6/site-packages/hcl/ply/yacc.py", line 335, in parse
14:32:35      return self.parseopt_notrack(input, lexer, debug, tracking, tokenfunc)
14:32:35    File "/usr/lib64/python3.6/site-packages/hcl/ply/yacc.py", line 1122, in parseopt_notrack
14:32:35      p.callable(pslice)
14:32:35    File "/usr/lib64/python3.6/site-packages/hcl/parser.py", line 355, in p_function_0
14:32:35      p[0] = p[1] + p[2] + self.flatten(p[3]) + p[4]
14:32:35    File "/usr/lib64/python3.6/site-packages/hcl/parser.py", line 395, in flatten
14:32:35      return ",".join(self.flatten(v) for v in value)
14:32:35    File "/usr/lib64/python3.6/site-packages/hcl/parser.py", line 395, in <genexpr>
14:32:35      return ",".join(self.flatten(v) for v in value)
14:32:35    File "/usr/lib64/python3.6/site-packages/hcl/parser.py", line 392, in flatten
14:32:35      + "}"
14:32:35    File "/usr/lib64/python3.6/site-packages/hcl/parser.py", line 391, in <genexpr>
14:32:35      + ",".join(key + ":" + self.flatten(value[key]) for key in value)
14:32:35    File "/usr/lib64/python3.6/site-packages/hcl/parser.py", line 413, in flatten
14:32:35      type(value),
14:32:35  TypeError: ('%s is of type %s; expected type of dict, list, tuple, or str', 'False', <class 'bool'>)
```
### Solution
To fix this issue, we need to use a more recent hcl version call hcl2 and flatten the list and dictionary.