### PR TITLE
Add support for proxy_containerized module in tf module cleaner.

### DIFF
--- a/terracumber/tf_module_cleaner.py
+++ b/terracumber/tf_module_cleaner.py
@@ -24,6 +24,8 @@ def get_default_modules(maintf_content, tf_resources_to_delete):
             exclusions.extend(['terminal', 'buildhost'])
         if 'proxy' in tf_resources_to_delete:
             exclusions.append('proxy')
+        if 'proxy_containerized' in tf_resources_to_delete:
+            exclusions.append('proxy_containerized')
         if 'monitoring-server' in tf_resources_to_delete:
             exclusions.append('monitoring-server')
 


### PR DESCRIPTION
## Context

Proxy module in 5.0 context is called proxy_containerized.
Add proxy_containerized reference to tf module cleaner to act like proxy module.