### PR TITLE
Add back proxy to inject repo module

### DIFF
--- a/terracumber/terraformer.py
+++ b/terracumber/terraformer.py
@@ -72,7 +72,7 @@ class Terraformer:
             except JSONDecodeError:
                 return 1
             for node in repos.keys():
-                if node == 'server':
+                if node == 'server' or node == 'proxy':
                     node_mu_repos = repos.get(node, None)
                     replacement_list = ["additional_repos = {"]
                     for name, url in node_mu_repos.items():


### PR DESCRIPTION
## Context

For proxy_containerized, we need to inject the repositories to get the last uyuni tools version.

## What does this PR ?

Add back support for proxy to repository injection module.