### PR TITLE
Remove proxy from repos injection

### DIFF
--- a/terracumber/terraformer.py
+++ b/terracumber/terraformer.py
@@ -72,7 +72,7 @@ class Terraformer:
             except JSONDecodeError:
                 return 1
             for node in repos.keys():
-                if node == 'server' or node == 'proxy':
+                if node == 'server':
                     node_mu_repos = repos.get(node, None)
                     replacement_list = ["additional_repos = {"]
                     for name, url in node_mu_repos.items():


### PR DESCRIPTION
For https://ci.suse.de/view/Manager/view/Manager-4.3/job/manager-4.3-qe-sle-update-NUE/ the recent changes in master branch causes pipeline to fail from the following:
```
[Shell Script -- set +x; source /home/jenkins/.credentials set -x; export TF_VAR_CONTAINER_REPOSITORY=null; export TF_VAR_CUCUMBER_GITREPO=https://github.com/SUSE/spacewalk.git; export TF_VAR_CUCUMBER_BRANCH=Manager-4.3; export TERRAFORM=/usr/bin/terraform; export TERRAFORM_PLUGINS=/usr/bin; ./terracumber-cli --outputdir /home/jenkins/workspace/manager-4.3-qe-sle-update-NUE/results --tf susemanager-ci/terracumber_config/tf_files/SUSEManager-4.3-SLE-update-NUE.tf --gitfolder /home/jenkins/workspace/manager-4.3-qe-sle-update-NUE/results/sumaform --logfile /home/jenkins/workspace/manager-4.3-qe-sle-update-NUE/results/30/sumaform.log --init --taint '.*(domain|main_disk|data_disk|database_disk|standalone_provisioning|server_extra_nfs_mounts).*' --custom-repositories /home/jenkins/workspace/manager-4.3-qe-sle-update-NUE/custom_repositories.json --sumaform-backend libvirt --use-tf-resource-cleaner --tf-resources-to-keep sles15sp4_minion --runstep provision ](https://ci.suse.de/view/Manager/view/Manager-4.3/job/manager-4.3-qe-sle-update-NUE/30/execution/node/32/log)(self time 303ms)
...
09:43:19  + set +x
09:43:19  Running terraform...
09:43:19  ERROR: make sure to have exactly 1 placeholder for additional repositories in susemanager-ci/terracumber_config/tf_files/SUSEManager-4.3-SLE-update-NUE.tf
```

I used this branch to have a successful pipeline run, feel free to have it adjusted. Merge with the current change will rollback the master.