### PR TITLE
Refactor how we handle errors in inject_repos function

### DIFF
--- a/terracumber-cli
+++ b/terracumber-cli
@@ -15,6 +15,7 @@ import terracumber.junit
 import terracumber.mailer
 import terracumber.utils
 import logging
+from json import JSONDecodeError
 
 # Set up logger
 logger = logging.getLogger(__name__)
@@ -225,15 +226,11 @@ def run_terraform(args, tf_vars):
                                                     args.tf_variables_description_file, args.tf_configuration_files)
     if args.custom_repositories:
         with open(args.custom_repositories, 'r') as repos_file:
-            error = terraform.inject_repos(repos_file)
-            if error == 1:
-                logger.error("ERROR: %s is not a well-formed JSON file", args.custom_repositories)
+            try:
+                terraform.inject_repos(repos_file)
+            except JSONDecodeError as error:
+                logger.error("ERROR: %s is not a well-formed JSON file:\n%s", args.custom_repositories, error)
                 return False
-            elif error == 2:
-                logger.error("ERROR: Make sure to have exactly 1 placeholder for additional repositories in %s", args.tf)
-                return False
-            elif error == 3:
-                logger.warning("WARNING: Proxy or server is missing the placeholder for additional repositories in %s", args.tf)
     if args.init:
         terraform.init()
     if args.taint:

--- a/terracumber/terraformer.py
+++ b/terracumber/terraformer.py
@@ -1,6 +1,6 @@
 """Run and manage terraform"""
 import fileinput
-from json import load, JSONDecodeError
+from json import load
 from os import environ, path, symlink, unlink
 from re import match, subn
 from shutil import copy
@@ -58,19 +58,10 @@ class Terraformer:
             self.is_prepared = True  # Mark as prepared
 
     def inject_repos(self, custom_repositories_json):
-        """Set additional repositories into the main.tf, so they are injected by sumaform
-
-        Returns:
-            0 if no error
-            1 if the json is not well-formed
-            2 if the main.tf has an incorrect number of placeholders
-        """
+        """Set additional repositories into the main.tf, so they are injected by sumaform"""
         self.prepare_environment()  # Ensure environment is prepared
         if custom_repositories_json:
-            try:
-                repos = load(custom_repositories_json)
-            except JSONDecodeError:
-                return 1
+            repos = load(custom_repositories_json)
             for node in repos.keys():
                 if node == 'server' or node == 'proxy':
                     node_mu_repos = repos.get(node, None)
@@ -80,16 +71,9 @@ class Terraformer:
                     replacement_list.append("\n}")
                     replacement = ''.join(replacement_list)
                     placeholder = f'//{node}_additional_repos'
-                    n_replaced = 0
                     for line in fileinput.input(f"{self.terraform_path}/main.tf", inplace=True):
                         (new_line, n) = subn(placeholder, replacement, line)
                         print(new_line, end='')
-                        n_replaced += n
-                    if n_replaced > 1:
-                        return 2
-                    elif n_replaced == 0:
-                        return 3
-        return 0
 
     def init(self):
         self.prepare_environment()  # Ensure environment is prepared


### PR DESCRIPTION
This refactor change the way how we handle errors, so we don't return integers as the result of the function, hiding some details, but we just raise the error to be handled on a higher level if necessary, which will come with more information to process.