### PR TITLE
Delete proxy and dhcp when deleting retail

### DIFF
--- a/terracumber/tf_module_cleaner.py
+++ b/terracumber/tf_module_cleaner.py
@@ -21,9 +21,9 @@ def get_default_modules(maintf_content, tf_resources_to_delete):
 
     if tf_resources_to_delete:
         if 'retail' in tf_resources_to_delete:
-            exclusions.extend(['terminal', 'buildhost','proxy','dhcp_dns'])
+            exclusions.extend(['terminal', 'buildhost', 'proxy', 'dhcp_dns'])
         if 'proxy' in tf_resources_to_delete:
-            exclusions.extend(['proxy','dhcp_dns'])
+            exclusions.extend(['proxy', 'dhcp_dns'])
         if 'monitoring-server' in tf_resources_to_delete:
             exclusions.append('monitoring_server')
 

--- a/terracumber/tf_module_cleaner.py
+++ b/terracumber/tf_module_cleaner.py
@@ -25,7 +25,7 @@ def get_default_modules(maintf_content, tf_resources_to_delete):
         if 'proxy' in tf_resources_to_delete:
             exclusions.extend(['proxy','dhcp_dns'])
         if 'monitoring-server' in tf_resources_to_delete:
-            exclusions.append('monitoring-server')
+            exclusions.append('monitoring_server')
 
     filtered_module_names = [name for name in module_names if all(exclusion not in name for exclusion in exclusions)]
 

--- a/terracumber/tf_module_cleaner.py
+++ b/terracumber/tf_module_cleaner.py
@@ -21,9 +21,9 @@ def get_default_modules(maintf_content, tf_resources_to_delete):
 
     if tf_resources_to_delete:
         if 'retail' in tf_resources_to_delete:
-            exclusions.extend(['terminal', 'buildhost'])
+            exclusions.extend(['terminal', 'buildhost','proxy','dhcp_dns'])
         if 'proxy' in tf_resources_to_delete:
-            exclusions.append('proxy')
+            exclusions.extend(['proxy','dhcp_dns'])
         if 'monitoring-server' in tf_resources_to_delete:
             exclusions.append('monitoring-server')
 


### PR DESCRIPTION
Delete proxy and dhcp when deleting proxy
## Context
 
With 5.0 deployment, we have a new module name dhcp_dns.

## What does this PR do ?

Add the possibility to delete dhcp_dns. By default, dhcp_dns will have terminal and proxy dependencies. So I changed the code to make sure to clean correctly the dhcp_dns. The dhcp_dns will be deleted when using the option retail. I will also delete proxy when the retail option is selected.