### PR TITLE
Simplify cleaning argument. Clean all proxy / retail / monitoring all…

### DIFF
--- a/terracumber-cli
+++ b/terracumber-cli
@@ -104,11 +104,26 @@ def parse_args():
     parser.add_argument('--bastion_ssh_key', help="""Bastion key to be use""", dest='bastion_ssh_key', default=None)
     parser.add_argument('--bastion_user', help="""Bastion user to be use""", dest='bastion_user', default='ec2-user')
     parser.add_argument('--bastion_hostname', help="""Bastion hostname to use""", dest='bastion_hostname', default=None)
-    parser.add_argument('--use-tf-resource-cleaner', help='Activate or deactivate the minion cleaner',
-                        action='store_true', default=False)
-    parser.add_argument('--tf-resources-to-keep', type=str, nargs='*', default=[], help='Space-separated list of minions resources to keep')
-    parser.add_argument('--tf-resources-to-delete', type=str, nargs='*', choices=['proxy', 'monitoring-server', 'retail'], default=[],
-                         help='List of default modules to force deletion')
+    parser.add_argument(
+        '--use-tf-resource-cleaner',
+        help='Activate or deactivate the Terraform resource cleaner',
+        action='store_true',
+        default=False
+    )
+    parser.add_argument(
+        '--tf-resources-to-keep',
+        type=str,
+        nargs='*',
+        default=[],
+        help='Space-separated list of specific Terraform resources to keep (e.g., minions, clients)'
+    )
+    parser.add_argument(
+        '--tf-resources-delete-all',
+        help='If set, delete all resources except the default exclusions (e.g., minion, client, terminal, buildhost, proxy, dhcp_dns, monitoring_server). If not set, only client-related resources will be removed.',
+        action='store_true',
+        default=False
+    )
+
 
     args = parser.parse_args()
     if args.runstep:
@@ -240,7 +255,7 @@ def run_terraform(args, tf_vars):
         terraform.taint(args.taint)
     if args.destroy:
         terraform.destroy()
-    result = terraform.apply(args.parallelism, args.use_tf_resource_cleaner, args.tf_resources_to_keep, args.tf_resources_to_delete)
+    result = terraform.apply(args.parallelism, args.use_tf_resource_cleaner, args.tf_resources_to_keep, args.tf_resources_delete_all)
     if result == 0:
         return True
     return False

--- a/terracumber/terraformer.py
+++ b/terracumber/terraformer.py
@@ -112,7 +112,7 @@ class Terraformer:
             print(resource)
             self.__run_command([self.terraform_bin, "taint", "%s" % resource])
 
-    def apply(self, parallelism=10, use_tf_resource_cleaner=False, tf_resources_to_keep=[], tf_resources_to_delete=[]):
+    def apply(self, parallelism=10, use_tf_resource_cleaner=False, tf_resources_to_keep=[], delete_all=False):
         """Run terraform apply after removing unselected resources from the main.tf.
 
         parallelism - Define the number of parallel resource operations. Defaults to 10 as specified by terraform.
@@ -122,7 +122,7 @@ class Terraformer:
         """
         self.prepare_environment()  # Ensure environment is prepared
         if use_tf_resource_cleaner:
-            remove_unselected_tf_resources(f"{self.terraform_path}/main.tf", tf_resources_to_keep, tf_resources_to_delete)
+            remove_unselected_tf_resources(f"{self.terraform_path}/main.tf", tf_resources_to_keep, delete_all)
 
         command_arguments = [self.terraform_bin, "apply", "-auto-approve", f"-parallelism={parallelism}"]
         for file in self.tfvars_files:


### PR DESCRIPTION
## What does this PR

This PR simplifies the main.tf manipulation options.
Previously, it was possible to delete proxy, retail, and monitoring resources separately. However, since these resources are strongly interconnected, this could lead to unintended issues. To prevent such situations, this PR updates the parameter to allow either a full cleanup of all resources or no cleanup at all.

Remove option `--tf-resources-to-delete`
Add option `--tf-resources-delete-all`