### PR TITLE
Inject additional repos to BV servers and proxies

### DIFF
--- a/terracumber-cli
+++ b/terracumber-cli
@@ -251,7 +251,7 @@ def run_terraform(args, tf_vars):
                 logger.error("ERROR: %s is not a well-formed JSON file", args.custom_repositories)
                 return False
             elif error == 2:
-                logger.error("ERROR: Make sure to have exactly 1 placeholder for additional repositories in %s", args.tf)
+                logger.error("ERROR: Make sure to have at most 2 placeholders for additional repositories in %s", args.tf)
                 return False
             elif error == 3:
                 logger.warning("WARNING: Proxy or server is missing the placeholder for additional repositories in %s", args.tf)

--- a/terracumber/terraformer.py
+++ b/terracumber/terraformer.py
@@ -89,11 +89,12 @@ class Terraformer:
                     replacement = ''.join(replacement_list)
                     placeholder = f'//{node}_additional_repos'
                     n_replaced = 0
-                    for line in fileinput.input(f"{self.terraform_path}/main.tf", inplace=True):
+                    print(f"Checking entries in {self.terraform_path}/modules/build_validation/main.tf")
+                    for line in fileinput.input(f"{self.terraform_path}/modules/build_validation/main.tf", inplace=True):
                         (new_line, n) = subn(placeholder, replacement, line)
                         print(new_line, end='')
                         n_replaced += n
-                    if n_replaced > 1:
+                    if n_replaced > 2:
                         return 2
                     elif n_replaced == 0:
                         # not a fatal error, just trigger a warning when the return is checked


### PR DESCRIPTION
Spotted during https://github.com/SUSE/spacewalk/issues/28600

Dedicated card https://github.com/SUSE/spacewalk/issues/29582

____

**This is only a temporary solution, we should refactor the script or use another mechanism to deal with additional repositories (e.g. tfvars)**

___



With the recent changes to make BV configuration dynamic which introduced a new dedicated sumaform module, the script no longer works as is.

It tries to replace placeholder comments like:

```
//server_additional_repos
```

with the constructed list of repositories. Such comments are no longer presents in susemanage-ci tf files, they now reside in the main.tf of the **build_validation** module.

See https://github.com/uyuni-project/sumaform/blob/master/modules/build_validation/main.tf#L145