### PR TITLE
Refactor injection of additional repos

### DIFF
--- a/terracumber-cli
+++ b/terracumber-cli
@@ -238,23 +238,30 @@ def get_git_credentials(args, tf_vars):
     return {'user': None, 'password': None}
 
 
-def run_terraform(args, tf_vars):
+def run_terraform(args, tf_vars) -> bool:
     """ Prepare the environment """
     terraform = terracumber.terraformer.Terraformer(args.gitfolder, args.tf,
                                                     args.sumaform_backend, tf_vars,
                                                     args.logfile, args.terraform_bin,
                                                     args.tf_variables_description_file, args.tf_configuration_files)
     if args.custom_repositories:
-        with open(args.custom_repositories, 'r') as repos_file:
-            error = terraform.inject_repos(repos_file)
-            if error == 1:
-                logger.error("ERROR: %s is not a well-formed JSON file", args.custom_repositories)
-                return False
-            elif error == 2:
-                logger.error("ERROR: Make sure to have at most 2 placeholders for additional repositories in %s", args.tf)
-                return False
-            elif error == 3:
-                logger.warning("WARNING: Proxy or server is missing the placeholder for additional repositories in %s", args.tf)
+        try:
+            with open(args.custom_repositories, 'r') as repos_file:
+                repos_data: dict = json.load(repos_file)
+        except json.JSONDecodeError:
+            logger.error("%s is not a well-formed JSON file", args.custom_repositories)
+            return False
+        except FileNotFoundError:
+            logger.error("Custom repositories file %s not found", args.custom_repositories)
+            return False
+        
+        try:
+            terraform.inject_repos(repos_data)
+        except Exception as e:
+            logger.error("Failed to process tfvars HCL file %s. Reason: %s", args.tf_configuration_files, e)
+            return False
+
+
     if args.init:
         terraform.init()
     if args.taint:


### PR DESCRIPTION
Related to https://github.com/SUSE/spacewalk/issues/29582

- [ ] Prerequisite: https://github.com/uyuni-project/sumaform/pull/2032

Refactor the logic to add custom repositories for server and proxy.
This is currently done by searching for some placeholder comments in Sumaform`s files and replacing them with the list of updated repositories obtained from the JSON input.

This PR refactors such code to make so that it reads the existing tfvars file(s) used for environment configuration and is able to create new ones where server and proxy entries (containerized or not) define also the list of additional repositories.