### PR TITLE
Add controller report to the get result download to get also the indi…

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-python-hcl2
+python-hcl2<8.0
 paramiko
 pygit2

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ setup(
     description="When Terraform meets Cucumber.",
     long_description=open("README.md").read(),
     install_requires=[
-        "python-hcl2",
+        "python-hcl2<8.0",
         "paramiko",
         "pygit2",
     ],

--- a/terracumber-cli
+++ b/terracumber-cli
@@ -290,15 +290,18 @@ def get_results(args, tf_vars, config, ctl_creds):
     ctl_creds['hostname'] = ctl
     cucumber = terracumber.cucumber.Cucumber(ctl_creds, False, 'AutoAddPolicy')
     # Pending: Make the lists of files and directories part of the tf file
-    files = ['output.*\.html', 'output.*\.json', 'spacewalk-debug\.tar\.bz2']
+    downloaded = cucumber.get_by_extensions(
+        config['CUCUMBER_RESULTS'], args.outputdir, ['.html', '.json'])
+    if not downloaded:
+        logger.warning("No .html or .json files found in %s at %s!",
+                       config['CUCUMBER_RESULTS'], ctl_creds['hostname'])
+    try:
+        cucumber.get('%s/%s' % (config['CUCUMBER_RESULTS'], r'spacewalk-debug\.tar\.bz2'),
+                     '%s' % args.outputdir)
+    except FileNotFoundError:
+        logger.warning("Nothing matched %s/%s at %s!", config['CUCUMBER_RESULTS'],
+                       'spacewalk-debug.tar.bz2', ctl_creds['hostname'])
     directories = ['screenshots', 'cucumber_report', 'logs', 'results_junit']
-    for copyfile in files:
-        try:
-            cucumber.get('%s/%s' % (config['CUCUMBER_RESULTS'], copyfile),
-                         '%s' % args.outputdir)
-        except FileNotFoundError:
-            logger.warning("Nothing matched %s/%s at %s!", config['CUCUMBER_RESULTS'],
-                           copyfile, ctl_creds['hostname'])
     for copydir in directories:
         try:
             cucumber.get_recursive('%s/%s' % (config['CUCUMBER_RESULTS'], copydir),

--- a/terracumber-cli
+++ b/terracumber-cli
@@ -284,7 +284,7 @@ def get_bastion_hostname(args, tf_vars):
         return None
 
 
-def get_results(args, tf_vars, config, ctl_creds):
+def get_results(args, tf_vars, config, ctl_creds, build_number):
     """ Get results from the controller after a cucumber execution """
     ctl = get_controller_hostname(args, tf_vars)
     ctl_creds['hostname'] = ctl
@@ -304,11 +304,20 @@ def get_results(args, tf_vars, config, ctl_creds):
     directories = ['screenshots', 'cucumber_report', 'logs', 'results_junit']
     for copydir in directories:
         try:
+            logger.info("Copying directory %s/%s to %s/%s", config['CUCUMBER_RESULTS'], copydir, args.outputdir, copydir)
             cucumber.get_recursive('%s/%s' % (config['CUCUMBER_RESULTS'], copydir),
                                    '%s/%s' % (args.outputdir, copydir))
         except FileNotFoundError:
             logger.warning("Remote directory %s/%s did not exist!", config['CUCUMBER_RESULTS'],
                            copydir)
+    # Copy results directory from build-specific location
+    try:
+        results_remote_path = '%s/results/%s' % (config['CUCUMBER_RESULTS'], build_number)
+        logger.info("Copying results directory %s to %s/results", results_remote_path, args.outputdir)
+        cucumber.get_recursive(results_remote_path, '%s/results' % args.outputdir)
+    except FileNotFoundError:
+        logger.warning("Remote results directory %s/results/%s did not exist!", config['CUCUMBER_RESULTS'],
+                       build_number)
     return True
 
 
@@ -494,7 +503,7 @@ def main():
 
     if (args.runall and results['output-tests']) or args.runstep == 'getresults':
         logger.info("Fetching files from controller to %s...", args.outputdir)
-        results['results'] = get_results(args, tf_vars, config, ctl_creds)
+        results['results'] = get_results(args, tf_vars, config, ctl_creds, template_data['timestamp'])
 
     if args.runstep == 'saltshaker_getresults':
         logger.info("Fetching files from Salt Shaker node to %s...", args.outputdir)

--- a/terracumber/cucumber.py
+++ b/terracumber/cucumber.py
@@ -103,18 +103,21 @@ class Cucumber:
         """
         downloaded = []
         sftp_client = self.ssh_client.open_sftp()
-        for entry in sftp_client.listdir_attr(remotedir):
-            if not stat.S_ISREG(entry.st_mode):
-                continue
-            _, ext = os.path.splitext(entry.filename)
-            if ext not in extensions:
-                continue
-            remote_path = remotedir.rstrip('/') + '/' + entry.filename
-            local_path = localdir.rstrip('/') + '/' + entry.filename
-            sftp_client.get(remote_path, local_path)
-            self.copy_atime_mtime(remote_path, local_path)
-            downloaded.append(remote_path)
-        return downloaded
+        try:
+            for entry in sftp_client.listdir_attr(remotedir):
+                if not stat.S_ISREG(entry.st_mode):
+                    continue
+                _, ext = os.path.splitext(entry.filename)
+                if ext not in extensions:
+                    continue
+                remote_path = remotedir.rstrip('/') + '/' + entry.filename
+                local_path = localdir.rstrip('/') + '/' + entry.filename
+                sftp_client.get(remote_path, local_path)
+                self.copy_atime_mtime(remote_path, local_path)
+                downloaded.append(remote_path)
+            return downloaded
+        finally:
+            sftp_client.close()
 
     def put_file(self, localpath, remotepath):
         """Put a file in the controller

--- a/terracumber/cucumber.py
+++ b/terracumber/cucumber.py
@@ -90,6 +90,32 @@ class Cucumber:
             raise FileNotFoundError
         return(copied_files)
 
+    def get_by_extensions(self, remotedir, localdir, extensions):
+        """Get all files from a remote directory whose extension is in `extensions`.
+
+        Keyword arguments:
+        remotedir  - A string with the full remote directory path
+        localdir   - A string with the local directory to copy files into
+        extensions - A list of file extensions to include, e.g. ['.html', '.json']
+
+        Returns a list of remote paths that were downloaded.
+        Subdirectories and files with other extensions are silently skipped.
+        """
+        downloaded = []
+        sftp_client = self.ssh_client.open_sftp()
+        for entry in sftp_client.listdir_attr(remotedir):
+            if not stat.S_ISREG(entry.st_mode):
+                continue
+            _, ext = os.path.splitext(entry.filename)
+            if ext not in extensions:
+                continue
+            remote_path = remotedir.rstrip('/') + '/' + entry.filename
+            local_path = localdir.rstrip('/') + '/' + entry.filename
+            sftp_client.get(remote_path, local_path)
+            self.copy_atime_mtime(remote_path, local_path)
+            downloaded.append(remote_path)
+        return downloaded
+
     def put_file(self, localpath, remotepath):
         """Put a file in the controller
 

--- a/test/test_cucumber.py
+++ b/test/test_cucumber.py
@@ -1,5 +1,4 @@
 from terracumber import cucumber
-import os
 import stat
 import unittest
 from unittest.mock import MagicMock, patch

--- a/test/test_cucumber.py
+++ b/test/test_cucumber.py
@@ -1,6 +1,8 @@
 from terracumber import cucumber
+import os
+import stat
 import unittest
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 
 class TestCucumber(unittest.TestCase):
@@ -83,6 +85,39 @@ class TestCucumber(unittest.TestCase):
         self.cucumber = cucumber.Cucumber(self.conn_data)
         self.cucumber.close()
         mock_sshclient.return_value.close.assert_called_once()
+
+    @patch('terracumber.cucumber.paramiko.SSHClient')
+    @patch('terracumber.cucumber.Cucumber.copy_atime_mtime')
+    def test_get_by_extensions(self, mock_copy_atime_mtime, mock_sshclient):
+        def make_entry(name, is_dir=False):
+            e = MagicMock()
+            e.filename = name
+            e.st_mode = stat.S_IFDIR if is_dir else stat.S_IFREG
+            return e
+
+        self.cucumber = cucumber.Cucumber(self.conn_data)
+        mock_sftp = mock_sshclient.return_value.open_sftp.return_value
+
+        # Downloads .html and .json, skips .txt and subdirectories
+        mock_sftp.listdir_attr.return_value = [
+            make_entry('output_core.html'),
+            make_entry('output_core.json'),
+            make_entry('notes.txt'),
+            make_entry('subdir', is_dir=True),
+        ]
+        result = self.cucumber.get_by_extensions('/remote/results', '/local/out', ['.html', '.json'])
+        self.assertEqual(sorted(result), sorted([
+            '/remote/results/output_core.html',
+            '/remote/results/output_core.json',
+        ]))
+        self.assertEqual(mock_sftp.get.call_count, 2)
+
+        # Empty directory returns empty list
+        mock_sftp.reset_mock()
+        mock_sftp.listdir_attr.return_value = []
+        result = self.cucumber.get_by_extensions('/remote/results', '/local/out', ['.html', '.json'])
+        self.assertEqual(result, [])
+        mock_sftp.get.assert_not_called()
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## What does this PR ?

  Summary

Add getresults step to copy the build-specific results directory from the controller. The /results/<buildnumber> directory was not being downloaded, causing test artifacts to be incomplete.

Changes

- Modified get_results() to accept and use build number parameter
- Added recursive copy of /root/spacewalk/testsuite/results/<buildnumber> to local output directory
- Added debug logging for directory copy operations to improve troubleshooting

Details

Test results are stored in two locations on the controller:
- Shared directories (screenshots, logs, results_junit, etc.): /root/spacewalk/testsuite/
- Build-specific results: /root/spacewalk/testsuite/results/<buildnumber>/

The previous implementation only copied the shared directories, missing the build-specific
results. This fix ensures all test artifacts are properly downloaded.