### PR TITLE
Only consider numbered directories during results cleanup

### DIFF
--- a/clean-old-results
+++ b/clean-old-results
@@ -36,17 +36,23 @@ function is_number() {
 }
 
 function remove_results() {
-  local RESULTS_PATH="${1}/*"
+  local RESULTS_PATH="${1}/[0-9]*"
   local SAVE=${2}
   local DRY_RUN=${3} 
-  TOTAL=$(ls -tld ${RESULTS_PATH} | wc -l)
+
+  # prevent error if there are no numbered directories
+  local ALL_RESULTS=($(ls -td ${RESULTS_PATH} 2>/dev/null))
+  local TOTAL=${#ALL_RESULTS[@]}
+
   if [ ${TOTAL} -gt ${SAVE} ]; then
     if [ "${DRY_RUN}" == "true" ]; then
       echo "DRY RUN: There are more than ${SAVE} result folders, would remove all except the ${SAVE} newest..."
     else
       echo "There are more than ${SAVE} result folders, removing all except the ${SAVE} newest..."
     fi
-    for RESULT in $(ls -td ${RESULTS_PATH} | tail -n +$((${SAVE}+1))); do
+    local TO_DELETE=("${ALL_RESULTS[@]:${SAVE}}")
+
+    for RESULT in "${TO_DELETE[@]}"; do
       if [ "${DRY_RUN}" == "true" ]; then
         echo "DRY RUN: Would remove ${RESULT}"
       else

--- a/clean-old-results
+++ b/clean-old-results
@@ -36,7 +36,9 @@ function is_number() {
 }
 
 function remove_results() {
-  local RESULTS_PATH="${1}/[0-9]*"
+  shopt -s extglob
+  
+  local RESULTS_PATH="${1}/+([0-9])"
   local SAVE=${2}
   local DRY_RUN=${3} 
 


### PR DESCRIPTION
Related to https://github.com/SUSE/spacewalk/issues/30681

```
18:24:28  + ./clean-old-results -r /home/jenkins/workspace/manager-head-qe-build-validation/results
18:24:28  There are more than 20 result folders, removing all except the 20 newest...
18:24:28  Removing /home/jenkins/workspace/manager-head-qe-build-validation/results/sumaform..
```

Avoids cleaning up sumaform directories, like shown above, by changing the regex so that it considers only directories whose name is composed only by digits. Plus a small refactor for readability.

